### PR TITLE
Add ship count to the header of the Fleet widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The Fleet widget displays the number of ships `[alive/total]` in its header.
 
 ## [0.24.1] - 2024-08-30
 ### Fixed

--- a/battleship/tui/screens/game.py
+++ b/battleship/tui/screens/game.py
@@ -83,19 +83,19 @@ class Game(Screen[None]):
 
         self.player_fleet = Fleet(
             id="player_fleet",
+            title="You",
             roster=strategy.roster,
             cell_factory=player_cell_factory,
             classes="player",
         )
-        self.player_fleet.border_title = "Your fleet"
         self.enemy_fleet = Fleet(
             id="enemy_fleet",
+            title="Enemy",
             roster=strategy.roster,
             cell_factory=enemy_cell_factory,
             allow_placing=False,
             classes="enemy",
         )
-        self.enemy_fleet.border_title = "Enemy fleet"
 
         self.board_map: dict[str, Board] = {
             self._player_name: self.player_board,

--- a/battleship/tui/styles.tcss
+++ b/battleship/tui/styles.tcss
@@ -106,6 +106,7 @@ Fleet {
   scrollbar-size-vertical: 1;
   padding: 1 0;
   border: wide $accent;
+  border-title-align: center;
 }
 
 Fleet.player {


### PR DESCRIPTION
Now the Fleet widget displays the number of ships `[alive/total]` in its header.

![Screenshot 2024-09-15 00:50:46](https://github.com/user-attachments/assets/f80acc39-2703-4053-b798-e31fb50ad114)
